### PR TITLE
Add Jasmine syntax 

### DIFF
--- a/syntax/Jasmine.JSON-tmLanguage
+++ b/syntax/Jasmine.JSON-tmLanguage
@@ -3,7 +3,6 @@
   "scopeName": "source.syntax_name",
   "fileTypes": ["spec.js"],
   "scopeName": "source.js.jasmine",
-  // According to the docs the following is ignored, used in TextMate. Added for completion sake
   "foldingStartMarker": "^.*\\bfunction\\s*(\\w+\\s*)?\\([^\\)]*\\)(\\s*\\{[^\\}]*)?\\s*$",
   "foldingStopMarker": "^\\s*\\}",
   "keyEquivalent": "^~J",
@@ -11,6 +10,20 @@
   "uuid": "03a4ea4f-bd92-4d51-b7aa-70b12bbdc854",
 
   "patterns": [
-    { "include": "source.js" }
+    {
+      "include": "source.js"
+    },
+    {
+      "match": "(describe)\\((\"\\w\")*(,\\s\\w+)?",
+        "captures": {
+          "1": { "name": "storage.type.js" }
+        }
+    },
+    {
+      "match": "(it)\\((\"\\w\")*(,\\s\\w+)?",
+        "captures": {
+          "1": { "name": "storage.type.js" }
+        }
+    }
   ]
 }

--- a/syntax/Jasmine.JSON-tmLanguage
+++ b/syntax/Jasmine.JSON-tmLanguage
@@ -1,8 +1,7 @@
 {
   "name": "Jasmine",
-  "scopeName": "source.syntax_name",
-  "fileTypes": ["spec.js"],
   "scopeName": "source.js.jasmine",
+  "fileTypes": ["spec.js"],
   "foldingStartMarker": "^.*\\bfunction\\s*(\\w+\\s*)?\\([^\\)]*\\)(\\s*\\{[^\\}]*)?\\s*$",
   "foldingStopMarker": "^\\s*\\}",
   "keyEquivalent": "^~J",
@@ -14,13 +13,13 @@
       "include": "source.js"
     },
     {
-      "match": "(describe)\\((\"\\w\")*(,\\s\\w+)?",
+      "match": "^\\s*(x?describe)\\(",
         "captures": {
           "1": { "name": "storage.type.js" }
         }
     },
     {
-      "match": "(it)\\((\"\\w\")*(,\\s\\w+)?",
+      "match": "^\\s*(x?it)\\(",
         "captures": {
           "1": { "name": "storage.type.js" }
         }

--- a/syntax/Jasmine.JSON-tmLanguage
+++ b/syntax/Jasmine.JSON-tmLanguage
@@ -1,0 +1,16 @@
+{
+  "name": "Jasmine",
+  "scopeName": "source.syntax_name",
+  "fileTypes": ["spec.js"],
+  "scopeName": "source.js.jasmine",
+  // According to the docs the following is ignored, used in TextMate. Added for completion sake
+  "foldingStartMarker": "^.*\\bfunction\\s*(\\w+\\s*)?\\([^\\)]*\\)(\\s*\\{[^\\}]*)?\\s*$",
+  "foldingStopMarker": "^\\s*\\}",
+  "keyEquivalent": "^~J",
+
+  "uuid": "03a4ea4f-bd92-4d51-b7aa-70b12bbdc854",
+
+  "patterns": [
+    { "include": "source.js" }
+  ]
+}

--- a/syntax/Jasmine.tmLanguage
+++ b/syntax/Jasmine.tmLanguage
@@ -20,6 +20,30 @@
 			<key>include</key>
 			<string>source.js</string>
 		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.js</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(describe)\(("\w")*(,\s\w+)?</string>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.js</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(it)\(("\w")*(,\s\w+)?</string>
+		</dict>
 	</array>
 	<key>scopeName</key>
 	<string>source.js.jasmine</string>

--- a/syntax/Jasmine.tmLanguage
+++ b/syntax/Jasmine.tmLanguage
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>fileTypes</key>
+	<array>
+		<string>spec.js</string>
+	</array>
+	<key>foldingStartMarker</key>
+	<string>^.*\bfunction\s*(\w+\s*)?\([^\)]*\)(\s*\{[^\}]*)?\s*$</string>
+	<key>foldingStopMarker</key>
+	<string>^\s*\}</string>
+	<key>keyEquivalent</key>
+	<string>^~J</string>
+	<key>name</key>
+	<string>Jasmine</string>
+	<key>patterns</key>
+	<array>
+		<dict>
+			<key>include</key>
+			<string>source.js</string>
+		</dict>
+	</array>
+	<key>scopeName</key>
+	<string>source.js.jasmine</string>
+	<key>uuid</key>
+	<string>03a4ea4f-bd92-4d51-b7aa-70b12bbdc854</string>
+</dict>
+</plist>

--- a/syntax/Jasmine.tmLanguage
+++ b/syntax/Jasmine.tmLanguage
@@ -30,7 +30,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(describe)\(("\w")*(,\s\w+)?</string>
+			<string>^\s*(x?describe)\(</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -42,7 +42,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(it)\(("\w")*(,\s\w+)?</string>
+			<string>^\s*(x?it)\(</string>
 		</dict>
 	</array>
 	<key>scopeName</key>


### PR DESCRIPTION
Hi! 

I've added the Jasmine syntax to the package (inheriting from the base JS). Here is a from/to to see how it looks:

**From**
![from](https://cloud.githubusercontent.com/assets/692077/3142691/aa001db8-e9ce-11e3-9596-aa45a97b1364.png)

**To**
![to](https://cloud.githubusercontent.com/assets/692077/3142692/b4fcb776-e9ce-11e3-91c4-a6ff71517cea.png)

If you're not convinced with the color on the `describe` and `it` methods, let me know. I didn't highlight the other common functions like `beforeEach` because I think it becomes unreadable.
