### PR TITLE
Open keybindings by platform

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -12,6 +12,7 @@
           {
             "caption":"Jasmine BDD",
             "children":[
+              // Settings
               {
                 "command":"open_file",
                 "args":{
@@ -29,36 +30,55 @@
               {
                 "caption":"-"
               },
+              // Keybindings - Default
               {
-                "command":"open_file",
-                "args":{
-                  "file":"${packages}/Jasmine BDD/Default.sublime-keymap"
-                },
-                "caption":"Key Bindings – Default"
+                  "command": "open_file",
+                  "args": {
+                      "file": "${packages}/Jasmine BDD/Default (OSX).sublime-keymap",
+                      "platform": "OSX"
+                  },
+                  "caption": "Key Bindings – Default"
               },
               {
-                "command":"open_file",
-                "args":{
-                  "file":"${packages}/Jasmine BDD/Default (Windows).sublime-keymap",
-                  "platform":"Windows"
-                },
-                "caption":"Key Bindings – User"
+                  "command": "open_file",
+                  "args": {
+                      "file": "${packages}/Jasmine BDD/Default (Linux).sublime-keymap",
+                      "platform": "Linux"
+                  },
+                  "caption": "Key Bindings – Default"
               },
               {
-                "command":"open_file",
-                "args":{
-                  "file":"${packages}/Jasmine BDD/Default (OSX).sublime-keymap",
-                  "platform":"OSX"
-                },
-                "caption":"Key Bindings – User"
+                  "command": "open_file",
+                  "args": {
+                      "file": "${packages}/Jasmine BDD/Default (Windows).sublime-keymap",
+                      "platform": "Windows"
+                  },
+                  "caption": "Key Bindings – Default"
+              },
+              // Keybindings - User
+              {
+                  "command": "open_file",
+                  "args": {
+                      "file": "${packages}/User/Default (OSX).sublime-keymap",
+                      "platform": "OSX"
+                  },
+                  "caption": "Key Bindings – User"
               },
               {
-                "command":"open_file",
-                "args":{
-                  "file":"${packages}/Jasmine BDD/Default (Linux).sublime-keymap",
-                  "platform":"Linux"
-                },
-                "caption":"Key Bindings – User"
+                  "command": "open_file",
+                  "args": {
+                      "file": "${packages}/User/Default (Linux).sublime-keymap",
+                      "platform": "Linux"
+                  },
+                  "caption": "Key Bindings – User"
+              },
+              {
+                  "command": "open_file",
+                  "args": {
+                      "file": "${packages}/User/Default (Windows).sublime-keymap",
+                      "platform": "Windows"
+                  },
+                  "caption": "Key Bindings – User"
               }
             ]
           }


### PR DESCRIPTION
Last thing I promise :)

Testing the package in both Sublime Text 2 and 3 it seems to work fine, but the Keybinding are a bit counterintuitive, `Keybindings - User` opens the default options, and `Keybinding - Default` opens a new keybinding file.

I only changed the JSON that defines them so it works like the other packages (Default = Package default, User = User by platform).

Thanks for all the feedback (and patience) and for merging the commands!
